### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/BARD/web-app/marvin/help/calculations/Validations.html
+++ b/BARD/web-app/marvin/help/calculations/Validations.html
@@ -101,9 +101,9 @@ https://www.chemaxon.com/wp-content/uploads/2010/05/UGM-poster-2010_RG_pKa.pdf--
 <H2><a class="anchor" name="References">6. References</A></H2>
 <OL>
    <LI><a class="text" name="Ref1"><i><b>PHYSPROP<sup>&copy;</sup> DATABASE</b></i></A></LI>
-   <LI><a class="text" name="Ref2">Klopman, G.;</A> Li, Ju-Yun.; Wang, S.; Dimayuga, M.: <i>J.Chem.Inf.Comput.Sci.</i>, <b>1994</b>, <i>34</i>, 752; <a href="http://dx.doi.org/10.1021/ci00020a009">doi</a></LI>
-   <LI><a class="text" name="Ref3">Miller</A>, K. J.; Savchik, J. A.: <i>J.Am.Chem.Soc.</i>, <b>1979</b>, <i>101</i>, 7206-7213; <a href="http://dx.doi.org/10.1021/ja00518a014">doi</a></LI>
-   <LI><a class="text" name="Ref4">Piet Th. van Duijnen.;</A> Swart, M.: <i>J.Phys.Chem. A</i>, <b>1998</b>, <i>102</i>, 2399-2407; <a href="http://dx.doi.org/10.1021/jp980221f">doi</a></LI>
+   <LI><a class="text" name="Ref2">Klopman, G.;</A> Li, Ju-Yun.; Wang, S.; Dimayuga, M.: <i>J.Chem.Inf.Comput.Sci.</i>, <b>1994</b>, <i>34</i>, 752; <a href="https://doi.org/10.1021/ci00020a009">doi</a></LI>
+   <LI><a class="text" name="Ref3">Miller</A>, K. J.; Savchik, J. A.: <i>J.Am.Chem.Soc.</i>, <b>1979</b>, <i>101</i>, 7206-7213; <a href="https://doi.org/10.1021/ja00518a014">doi</a></LI>
+   <LI><a class="text" name="Ref4">Piet Th. van Duijnen.;</A> Swart, M.: <i>J.Phys.Chem. A</i>, <b>1998</b>, <i>102</i>, 2399-2407; <a href="https://doi.org/10.1021/jp980221f">doi</a></LI>
 </OL>
 
 

--- a/BARD/web-app/marvin/help/calculations/charge.html
+++ b/BARD/web-app/marvin/help/calculations/charge.html
@@ -160,10 +160,10 @@ This result agrees with the published result, see <A HREF="#ref5">Ref.5.</A>
 <H2><A class="anchor" NAME="References">4. References</A></H2>
 
 <OL>
-<LI><a class="text" name="ref1"></a>Mulliken, R.S., <i>J. Chem. Phys.,</i> <b>1934,</b> <i>2,</i> 782; <a href="http://dx.doi.org/10.1063/1.1749394">doi</a></LI>
+<LI><a class="text" name="ref1"></a>Mulliken, R.S., <i>J. Chem. Phys.,</i> <b>1934,</b> <i>2,</i> 782; <a href="https://doi.org/10.1063/1.1749394">doi</a></LI>
 <LI>McWeeny, R., <i>Coulson's Valence</i>, Oxford University Press, <b>1979</b></LI>
 <LI>Dewar, M.J.S., <i>The Molecular Orbital Theory of Organic Chemistry</i>, McGraw-Hill, and Inc., <b>1969</b></LI>
-<LI>Gasteiger, J.; Marsili, M., <i>Tetrahedron,</i> <b>1980,</b> <i>36,</i> 3219; <a href="http://dx.doi.org/10.1016/0040-4020(80)80168-2">doi</a></LI>
+<LI>Gasteiger, J.; Marsili, M., <i>Tetrahedron,</i> <b>1980,</b> <i>36,</i> 3219; <a href="https://doi.org/10.1016/0040-4020(80)80168-2">doi</a></LI>
 <LI><A class="text" NAME="ref5"></A>Stewart, R., <i>The Proton: Applications to Organic Chemistry</i>, Academic Press, Inc., <b>1985</b>, 72</LI>
 
 </OL>

--- a/BARD/web-app/marvin/help/calculations/chargegroup.html
+++ b/BARD/web-app/marvin/help/calculations/chargegroup.html
@@ -119,9 +119,9 @@ The structure field offers a context menu from MarvinView.
 <h2>References</h2>
 <ul>
 	<li><a class="text" name="ref3">Miller, K. J.; Savchik, J. A., <i>J.
-	Am. Chem. Soc.</i>, <b>1979</b>, <i>101</i>, 7206-7213; <a href="http://dx.doi.org/10.1021/ja00518a014">doi</a> </a></li>
+	Am. Chem. Soc.</i>, <b>1979</b>, <i>101</i>, 7206-7213; <a href="https://doi.org/10.1021/ja00518a014">doi</a> </a></li>
 	<li><a class="text" name="ref4">Jensen, L.; Åstrand, P.-O.; Osted, A.; Kongsted, J.; Mikkelsen, K.V. <i>J.
-	Chem. Phys.</i>, <b>2002</b>, <i>116</i>, 4001-4010; <a href="http://dx.doi.org/10.1063/1.1433747">doi</a> </a></li>
+	Chem. Phys.</i>, <b>2002</b>, <i>116</i>, 4001-4010; <a href="https://doi.org/10.1063/1.1433747">doi</a> </a></li>
 </ul>
 
 </body>

--- a/BARD/web-app/marvin/help/calculations/elemanal.html
+++ b/BARD/web-app/marvin/help/calculations/elemanal.html
@@ -92,15 +92,15 @@ Ctrl+C, the structure field offers a context menu from MarvinView.
 	<LI><A NAME="ref1"></A>Atom weights:
 	M. E. Wieser, &quot;Atomic weights of the elements 2005 (IUPAC
 	Technical Report)&quot; Pure Appl. Chem., Vol. 78, No. 11, pp.
-	2051-2066, 2006; <A HREF="http://dx.doi.org/10.1351/pac200678112051">doi</A>
+	2051-2066, 2006; <A HREF="https://doi.org/10.1351/pac200678112051">doi</A>
 	<LI><A NAME="ref2"></A>Isotope
 	weights: G.Audi and A.H.Wapstra, &quot;The 1995 update to the atomic
 	mass evaluation&quot; Nuclear Physics A595 vol. 4, pp. 409-480,
-	1995; <A HREF="http://dx.doi.org/10.1016/0375-9474(95)00445-9">doi</A>
+	1995; <A HREF="https://doi.org/10.1016/0375-9474(95)00445-9">doi</A>
 	<LI><A NAME="ref3"></A>The Hill system: E. A. Hill, &quot;On A
 	System Of Indexing Chemical Literature; Adopted By The
 	Classification Division Of The U. S. Patent Office&quot;. J. Am.
-	Chem. Soc., 22(8), pp. 478-494, 1900; <A HREF="http://dx.doi.org/10.1021/ja02046a005">doi</A>
+	Chem. Soc., 22(8), pp. 478-494, 1900; <A HREF="https://doi.org/10.1021/ja02046a005">doi</A>
 </UL>
 </BODY>
 </HTML>

--- a/BARD/web-app/marvin/help/calculations/geometrygroup.html
+++ b/BARD/web-app/marvin/help/calculations/geometrygroup.html
@@ -319,19 +319,19 @@ atoms (|q<sub>i</sub>| is the absolute value of the partial charge of the atom).
 <h2>References</h2>
 <ul>
 <li>Randic,M.,<i> Chem. Phys. Lett.,</i> <b>1993</b>, <i>211,</i> pp 478-483;
-<a href="http://dx.doi.org/10.1016/0009-2614(93)87094-J">doi</a></li>
+<a href="https://doi.org/10.1016/0009-2614(93)87094-J">doi</a></li>
 
 <li>Lucic, B., Lukovits, I., Nikolic, S., Trinajstic, N., <i>J. Chem. Inf. Comput.
-Sci.,</i> <b>2001</b>, <i>41(3),</i> pp 527-535; <a href="http://dx.doi.org/10.1021/ci0000777">doi</a></li>
+Sci.,</i> <b>2001</b>, <i>41(3),</i> pp 527-535; <a href="https://doi.org/10.1021/ci0000777">doi</a></li>
 
 <li>Wiener, H., <i>J. Am. Chem. Soc.,</i> <b>1947,</b> <i>69(1)</i> pp 17 - 20;
-<a href="http://dx.doi.org/10.1021/ja01193a005">doi</a></li>
+<a href="https://doi.org/10.1021/ja01193a005">doi</a></li>
 
 <li><a class="text" name="ref4">Ertl, P., Rohde, B., Selzer, P., <i>J.
-	Med. Chem.</i>, <b>2000,</b> <i>43,</i> pp. 3714-3717; <a href="http://dx.doi.org/10.1021/jm000942e">doi</a></a></li>
+	Med. Chem.</i>, <b>2000,</b> <i>43,</i> pp. 3714-3717; <a href="https://doi.org/10.1021/jm000942e">doi</a></a></li>
 
 <li><a class="text" name="ref6">Ferrara, P,. Apostolakis J., Caflisch A., <i>Proteins</i>
-	<b>2002,</b> <i>46,</i> 24-33; <a href="http://dx.doi.org/10.1002/prot.10001">doi</a></a></li>
+	<b>2002,</b> <i>46,</i> 24-33; <a href="https://doi.org/10.1002/prot.10001">doi</a></a></li>
 </ul>
 
 </body>

--- a/BARD/web-app/marvin/help/calculations/logPlogD.html
+++ b/BARD/web-app/marvin/help/calculations/logPlogD.html
@@ -328,11 +328,11 @@ lignocaine as function of pH.
 <H2><A class="anchor" NAME="References"></a>7. References</H2>
 <OL>
 
-<LI><A class="text" NAME="Ref1">Viswanadhan, V. N.; Ghose, A. K.; Revankar, G. R. and Robins, R. K., <i> J.Chem.Inf.Comput.Sci.</i>, <b>1989</b>, <i>29</i>, 3, 163-172; <a href="http://dx.doi.org/10.1021/ci00063a006">doi</a></A></LI>
-<li><a class="text" name="Ref1a">Klopman, G.; Li, Ju-Yun.; Wang, S.; Dimayuga,  M.: <i>J.Chem.Inf.Comput.Sci.</i>, <b>1994</b>, <i>34</i>, 752; <a href="http://dx.doi.org/10.1021/ci00020a009">doi</a></a></li>
+<LI><A class="text" NAME="Ref1">Viswanadhan, V. N.; Ghose, A. K.; Revankar, G. R. and Robins, R. K., <i> J.Chem.Inf.Comput.Sci.</i>, <b>1989</b>, <i>29</i>, 3, 163-172; <a href="https://doi.org/10.1021/ci00063a006">doi</a></A></LI>
+<li><a class="text" name="Ref1a">Klopman, G.; Li, Ju-Yun.; Wang, S.; Dimayuga,  M.: <i>J.Chem.Inf.Comput.Sci.</i>, <b>1994</b>, <i>34</i>, 752; <a href="https://doi.org/10.1021/ci00020a009">doi</a></a></li>
 <li>PhysProp<sup>&copy;</sup> database, <a href="http://esc.syrres.com/interkow/pp1357.htm">webpage</a></li>
-<LI><A class="text" NAME="Ref2">Csizmadia, F.; Tsantili-Kakoulidou, A.; Panderi, I. and Darvas, F., <i>J.Pharm.Sci.</i>, <b>1997</b>, <i>86</i>, 7, 865-871; <a href="http://dx.doi.org/10.1021/js960177k">doi</a></A></LI>
-<LI><A class="text" NAME="Ref3">Bouchard, G.; Carrupt, P. A.; Testa, B.; Gobry, V. and Girault, H. H., <i>Pharm.Res.</i>, <b>2001</b>, <i>18</i>, 5, 702-708; <a href="http://dx.doi.org/10.1023/A:1011001914685">doi</a></A></LI>
+<LI><A class="text" NAME="Ref2">Csizmadia, F.; Tsantili-Kakoulidou, A.; Panderi, I. and Darvas, F., <i>J.Pharm.Sci.</i>, <b>1997</b>, <i>86</i>, 7, 865-871; <a href="https://doi.org/10.1021/js960177k">doi</a></A></LI>
+<LI><A class="text" NAME="Ref3">Bouchard, G.; Carrupt, P. A.; Testa, B.; Gobry, V. and Girault, H. H., <i>Pharm.Res.</i>, <b>2001</b>, <i>18</i>, 5, 702-708; <a href="https://doi.org/10.1023/A:1011001914685">doi</a></A></LI>
 
 </OL>
 

--- a/BARD/web-app/marvin/help/calculations/other.html
+++ b/BARD/web-app/marvin/help/calculations/other.html
@@ -245,7 +245,7 @@ be disabled when it is selected.)
 <ul>
 <li><a class="text" name="ref1"></a>Viswanadhan, V. N.; Ghose, A. K.; Revankar,
 	G. R.; Robins, R. K., <i>J. Chem. Inf. Comput. Sci.</i>, <b>1989</b>, <i>29</i>,
-	163-172; <a href="http://dx.doi.org/10.1021/ci00063a006">doi</a> </li>
+	163-172; <a href="https://doi.org/10.1021/ci00063a006">doi</a> </li>
 <li><a class="text" name="ref2">Isaacs, N.S., <i>Physical Organic
 	Chemistry</i>, John Wiley & Sons, Inc., New York, <b>1987</b>,</a> ISBN 0582218632. </li>
 <li> <a class="text" name="ref3">Streitwieser, A., <i>Molecular Orbital Theory for Organic Chemists,</i> John Wiley, <b>1961</b>,</a> ISBN 0471833584.</li>

--- a/BARD/web-app/marvin/help/calculations/pKa.html
+++ b/BARD/web-app/marvin/help/calculations/pKa.html
@@ -303,8 +303,8 @@ Table 3. Calculated and Observed Acidity Constants
 <li><a href="http://www.chemaxon.com/conf/Prediction_of_dissociation_constant_using_microconstants.pdf">Prediction of dissociation constant using microconstants</a>, J. Szegezdi and F. Csizmadia, 27th ACS National Meeting, Anaheim, California · March 28-April 1, 2004</li>
 <li><a href="https://www.chemaxon.com/conf/Calculating_pKa_values_of_small_and_large_molecules.pdf">Calculating pKa values of small and large molecules</a>, J. Szegezdi and F. Csizmadia, American Chemical Society Spring meeting, March 25-29th, 2007</li>
 <LI><A class="text" NAME="ref3">Clark, F. H.; Cahoon, N. M., <i>J. Pharm. Sci.</i>, <b>1987</b>, <i>76</i>, 8, 611-620</A></LI>
-<LI>Dixon, S. L.; Jurs, P. C., <i>J. Comp. Chem.</i>, <b>1993</b>, <i>14</i>, 12, 1460-1467; <a href="http://dx.doi.org/10.1002/jcc.540141208">doi</a></LI>
-<LI>Csizmadia, F.; Tsantili-Kakoulidou, A.; Panderi, I.; Darvas, F., <i>J. Pharm. Sci.</i>, <b>1997</b>, <i>86</i>, 7, 865-871; <a href="http://dx.doi.org/10.1021/js960177k">doi</a></LI>
+<LI>Dixon, S. L.; Jurs, P. C., <i>J. Comp. Chem.</i>, <b>1993</b>, <i>14</i>, 12, 1460-1467; <a href="https://doi.org/10.1002/jcc.540141208">doi</a></LI>
+<LI>Csizmadia, F.; Tsantili-Kakoulidou, A.; Panderi, I.; Darvas, F., <i>J. Pharm. Sci.</i>, <b>1997</b>, <i>86</i>, 7, 865-871; <a href="https://doi.org/10.1021/js960177k">doi</a></LI>
 
 </OL>
 

--- a/BARD/web-app/marvin/help/calculations/partitioning.html
+++ b/BARD/web-app/marvin/help/calculations/partitioning.html
@@ -183,15 +183,15 @@ menu.</p>
 <ol>
 <li><a class="text" name="ref1"></a>Viswanadhan, V. N.; Ghose, A. K.; Revankar,
 	G. R.; Robins, R. K., <i>J. Chem. Inf. Comput. Sci.</i>, <b>1989</b>, <i>29</i>,
-	163-172; <a href="http://dx.doi.org/10.1021/ci00063a006">doi</a>
+	163-172; <a href="https://doi.org/10.1021/ci00063a006">doi</a>
 </li>
 <li><a class="text" name="ref2">Klopman, G.;</a> Li, Ju-Yun.; Wang, S.; Dimayuga,
 M.: <i>J.Chem.Inf.Comput.Sci.</i>, <b>1994</b>, <i>34</i>, 752;
-<a href="http://dx.doi.org/10.1021/ci00020a009">doi</a></li>
+<a href="https://doi.org/10.1021/ci00020a009">doi</a></li>
 <li>PHYSPROP<sup>&copy;</sup> database</li>
 <li><a class="text" name="ref3"></a>Csizmadia, F; Tsantili-Kakoulidou, A.;
 	Pander, I.; Darvas, F., <i>J. Pharm. Sci.</i>, <b>1997</b>, <i>86</i>,
-	865-871; <a href="http://dx.doi.org/10.1021/js960177k">doi</a>
+	865-871; <a href="https://doi.org/10.1021/js960177k">doi</a>
 </li>
 </ol>
 

--- a/BARD/web-app/marvin/help/calculations/references.html
+++ b/BARD/web-app/marvin/help/calculations/references.html
@@ -10,11 +10,11 @@
 
 <h2>Elemental Analysis</h2>
 <ul><li> 
-Wieser,M. E., <i>Pure Appl. Chem., </i>Vol. 78, No. 11, pp. 2051-2066, 2006; <a href="http://dx.doi.org/10.1351/pac200678112051">doi</a>
+Wieser,M. E., <i>Pure Appl. Chem., </i>Vol. 78, No. 11, pp. 2051-2066, 2006; <a href="https://doi.org/10.1351/pac200678112051">doi</a>
 	</li>
-<li>Audi, G.; Wapstra, A.H.,  <i>Nuclear Physics</i> A595 vol. 4, pp. 409-480, 1995; <a href="http://dx.doi.org/10.1016/0375-9474(95)00445-9">doi</a>
+<li>Audi, G.; Wapstra, A.H.,  <i>Nuclear Physics</i> A595 vol. 4, pp. 409-480, 1995; <a href="https://doi.org/10.1016/0375-9474(95)00445-9">doi</a>
 	</li>
-<li>Hill, E. A., <i>J. Am. Chem. Soc.,</i> 22(8), pp. 478-494, 1900; <a href="http://dx.doi.org/10.1021/ja02046a005">doi</a>	
+<li>Hill, E. A., <i>J. Am. Chem. Soc.,</i> 22(8), pp. 478-494, 1900; <a href="https://doi.org/10.1021/ja02046a005">doi</a>	
 	</li>
 </ul>
 
@@ -30,8 +30,8 @@ IUPAC Provisional Recommendations for the Nomenclature of Organic Chemistry</a>
 <ul>
 <li><a href="http://www.chemaxon.com/conf/Prediction_of_dissociation_constant_using_microconstants.pdf">Prediction of dissociation constant using microconstants</a>, J. Szegezdi and F. Csizmadia, 27th ACS National Meeting, Anaheim, California, March 28-April 1, 2004</li>
 <li><a href="https://www.chemaxon.com/conf/Calculating_pKa_values_of_small_and_large_molecules.pdf">Calculating pKa values of small and large molecules</a>, J. Szegezdi and F. Csizmadia, American Chemical Society Spring meeting, March 25-29th, 2007</li>
-<li>Dixon, S. L.; Jurs, P. C., <i>J. Comp. Chem.</i>, 1993, <i>14</i>, 12, 1460-1467; <a href="http://dx.doi.org/10.1002/jcc.540141208">doi</a></li>
-<li>Csizmadia, F.; Tsantili-Kakoulidou, A.; Panderi, I.; Darvas, F., <i>J. Pharm. Sci.</i>, 1997, <i>86</i>, 7, 865-871; <a href="http://dx.doi.org/10.1021/js960177k">doi</a></li>
+<li>Dixon, S. L.; Jurs, P. C., <i>J. Comp. Chem.</i>, 1993, <i>14</i>, 12, 1460-1467; <a href="https://doi.org/10.1002/jcc.540141208">doi</a></li>
+<li>Csizmadia, F.; Tsantili-Kakoulidou, A.; Panderi, I.; Darvas, F., <i>J. Pharm. Sci.</i>, 1997, <i>86</i>, 7, 865-871; <a href="https://doi.org/10.1021/js960177k">doi</a></li>
 <li>Clark, F. H.; Cahoon, N. M., <i>J. Pharm. Sci.</i>, 1987, <i>76</i>, 8, 611-620</li>
 
 </ul>
@@ -39,21 +39,21 @@ IUPAC Provisional Recommendations for the Nomenclature of Organic Chemistry</a>
 <h2>Partitioning</h2>
 <ul>
 
-<li>Viswanadhan, V. N.; Ghose, A. K.; Revankar, G. R. and Robins, R. K., <i> J.Chem.Inf.Comput.Sci.</i>, 1989, <i>29</i>, 3, 163-172; <a href="http://dx.doi.org/10.1021/ci00063a006">doi</a></li>
-<li>Klopman, G.; Li, Ju-Yun.; Wang, S.; Dimayuga,  M.: <i>J.Chem.Inf.Comput.Sci.</i>, <b>1994</b>, <i>34</i>, 752; <a href="http://dx.doi.org/10.1021/ci00020a009">doi</a></li>
+<li>Viswanadhan, V. N.; Ghose, A. K.; Revankar, G. R. and Robins, R. K., <i> J.Chem.Inf.Comput.Sci.</i>, 1989, <i>29</i>, 3, 163-172; <a href="https://doi.org/10.1021/ci00063a006">doi</a></li>
+<li>Klopman, G.; Li, Ju-Yun.; Wang, S.; Dimayuga,  M.: <i>J.Chem.Inf.Comput.Sci.</i>, <b>1994</b>, <i>34</i>, 752; <a href="https://doi.org/10.1021/ci00020a009">doi</a></li>
 <li>PhysProp<sup>&copy;</sup> database, <a href="http://esc.syrres.com/interkow/pp1357.htm">webpage</a></li>
-<li>Csizmadia, F.; Tsantili-Kakoulidou, A.; Panderi, I., Darvas, F., <i>J.Pharm.Sci.</i>, 1997, <i>86</i>, 7, 865-871; <a href="http://dx.doi.org/10.1021/js960177k">doi</a></li>
-<li>Bouchard, G.; Carrupt, P. A.; Testa, B.; Gobry, V. and Girault, H. H., <i>Pharm.Res.</i>, 2001, <i>18</i>, 5, 702-708; <a href="http://dx.doi.org/10.1023/A:1011001914685">doi</a></li>
+<li>Csizmadia, F.; Tsantili-Kakoulidou, A.; Panderi, I., Darvas, F., <i>J.Pharm.Sci.</i>, 1997, <i>86</i>, 7, 865-871; <a href="https://doi.org/10.1021/js960177k">doi</a></li>
+<li>Bouchard, G.; Carrupt, P. A.; Testa, B.; Gobry, V. and Girault, H. H., <i>Pharm.Res.</i>, 2001, <i>18</i>, 5, 702-708; <a href="https://doi.org/10.1023/A:1011001914685">doi</a></li>
 </ul>
 
 <h2>Charge</h2>
 <ul>
 
-<li>Miller, K. J.; Savchik, J. A., <i>J. Am. Chem. Soc.</i>, 1979, <i>101</i>, 7206-7213; <a href="http://dx.doi.org/10.1021/ja00518a014">doi</a> </li>
-<li>Mulliken, R.S., <i>J. Chem. Phys.,</i> 1934, <i>2,</i> 782; <a href="http://dx.doi.org/10.1063/1.1749394">doi</a></li>
+<li>Miller, K. J.; Savchik, J. A., <i>J. Am. Chem. Soc.</i>, 1979, <i>101</i>, 7206-7213; <a href="https://doi.org/10.1021/ja00518a014">doi</a> </li>
+<li>Mulliken, R.S., <i>J. Chem. Phys.,</i> 1934, <i>2,</i> 782; <a href="https://doi.org/10.1063/1.1749394">doi</a></li>
 <li>McWeeny, R., <i>Coulson's Valence</i>, Oxford University Press, 1979, ISBN 0198551452</li>
 <li>Dewar, M.J.S., <i>The Molecular Orbital Theory of Organic Chemistry</i>, McGraw-Hill, and Inc., 1969</li>
-<li>Gasteiger, J.; Marsili, M., <i>Tetrahedron,</i> 1980, <i>36,</i> 3219; <a href="http://dx.doi.org/10.1016/0040-4020(80)80168-2">doi</a></li>
+<li>Gasteiger, J.; Marsili, M., <i>Tetrahedron,</i> 1980, <i>36,</i> 3219; <a href="https://doi.org/10.1016/0040-4020(80)80168-2">doi</a></li>
 <li>Stewart, R., <i>The Proton: Applications to Organic Chemistry</i>, Academic Press, Inc., 1985, 72, ISBN 0126703701</li>
 
 </ul>
@@ -66,16 +66,16 @@ IUPAC Provisional Recommendations for the Nomenclature of Organic Chemistry</a>
 
 <h2>Geometry</h2>
 <ul>
-<li>Randic,M.,<i> Chem. Phys. Lett.,</i> 1993, <i>211,</i> pp 478-483; <a href="http://dx.doi.org/10.1016/0009-2614(93)87094-J">doi</a></li>
-<li>Lucic, B., Lukovits, I., Nikolic, S., Trinajstic, N., <i>J. Chem. Inf. Comput. Sci.,</i> 2001, <i>41(3),</i> pp 527-535; <a href="http://dx.doi.org/10.1021/ci0000777">doi</a></li>
-<li>Wiener, H., <i>J. Am. Chem. Soc.,</i> 1947, <i>69(1)</i> pp 17 - 20; <a href="http://dx.doi.org/10.1021/ja01193a005>doi</a></li>
-<li>Ertl, P., Rohde, B., Selzer, P., <i>J. Med. Chem.</i>, 2000, <i>43,</i> pp. 3714-3717; <a href="http://dx.doi.org/10.1021/jm000942e">doi</a></li>
-<li>Ferrara, P,. Apostolakis J., Caflisch A., <i>Proteins</i>,2002, <i>46,</i> 24-33; <a href="http://dx.doi.org/10.1002/prot.10001">doi</a></li>
+<li>Randic,M.,<i> Chem. Phys. Lett.,</i> 1993, <i>211,</i> pp 478-483; <a href="https://doi.org/10.1016/0009-2614(93)87094-J">doi</a></li>
+<li>Lucic, B., Lukovits, I., Nikolic, S., Trinajstic, N., <i>J. Chem. Inf. Comput. Sci.,</i> 2001, <i>41(3),</i> pp 527-535; <a href="https://doi.org/10.1021/ci0000777">doi</a></li>
+<li>Wiener, H., <i>J. Am. Chem. Soc.,</i> 1947, <i>69(1)</i> pp 17 - 20; <a href="https://doi.org/10.1021/ja01193a005>doi</a></li>
+<li>Ertl, P., Rohde, B., Selzer, P., <i>J. Med. Chem.</i>, 2000, <i>43,</i> pp. 3714-3717; <a href="https://doi.org/10.1021/jm000942e">doi</a></li>
+<li>Ferrara, P,. Apostolakis J., Caflisch A., <i>Proteins</i>,2002, <i>46,</i> 24-33; <a href="https://doi.org/10.1002/prot.10001">doi</a></li>
 </ul>
 
 <h2>Other</h2>
 <ul>
-<li>Viswanadhan, V. N.; Ghose, A. K.; Revankar,	G. R.; Robins, R. K., <i>J. Chem. Inf. Comput. Sci.</i>, 1989, <i>29</i>, 163-172; <a href="http://dx.doi.org/10.1021/ci00063a006">doi</a></li>
+<li>Viswanadhan, V. N.; Ghose, A. K.; Revankar,	G. R.; Robins, R. K., <i>J. Chem. Inf. Comput. Sci.</i>, 1989, <i>29</i>, 163-172; <a href="https://doi.org/10.1021/ci00063a006">doi</a></li>
 <li>Isaacs, N.S., <i>Physical Organic Chemistry</i>, John Wiley & Sons, Inc., New York, 1987, ISBN 0582218632 </li>
 <li>Streitwieser, A., <i>Molecular Orbital Theory for Organic Chemists,</i> John Wiley, 1961, ISBN 0471833584.</li>
 </ul>


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!